### PR TITLE
[pytorch] fix pip_check test failure for tox/pyproject-api packaging incompatibility

### DIFF
--- a/test/dlc_tests/sanity/test_pre_release.py
+++ b/test/dlc_tests/sanity/test_pre_release.py
@@ -678,6 +678,12 @@ def test_pip_check(image):
             rf"tf-models-official 2.9.2 has requirement tensorflow-text~=2.9.0, but you have tensorflow-text 2.10.0."
         )
 
+    # tox and pyproject-api are installed by the OSS compliance tooling (generate_oss_compliance.sh)
+    # and require packaging>=25, but packaging may be constrained to an older version by other deps.
+    allowed_exceptions.append(
+        r"^(tox|pyproject-api) \d+(\.\d+)* has requirement packaging>=\d+, but you have packaging \d+(\.\d+)* which is incompatible\.$"
+    )
+
     if framework in ["pytorch"]:
         exception_strings = []
 


### PR DESCRIPTION
*GitHub Issue #, if available:*

N/A

### Description

The OSS compliance tooling (`generate_oss_compliance.sh`) installs `tox` and `pyproject-api` inside the container as transitive dependencies of `pip-licenses`. These packages require `packaging>=25`, but `packaging` gets constrained to an older version (24.2) by other dependencies in the container.

This adds an allowed exception for this known incompatibility in `test_pip_check`, following the same pattern used for other transitive dependency conflicts (e.g., awscli pyyaml, aiobotocore botocore).

This fix unblocks all 4 PyTorch Inference 2.6 RC building pipelines which are currently failing at the `SANITY_CHECK` stage due to `test_pip_check` failures.

### Tests Run

```
/buildspec pytorch/inference/buildspec-2-6-ec2.yml
/tests sanity security
```

### Formatting
- [x] I have run `black -l 100` on my code

### PR Checklist

- [x] I've prepended PR tag with frameworks/job this applies to : [pytorch]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image

### Pytest Marker Checklist

N/A - no new tests added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.